### PR TITLE
Fix broken Browserstack Tunnel link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install --save-dev wdio-browserstack-service
 
 ## Configuration
 
-WebdriverIO has Browserstack support out of the box. You should simply set `user` and `key` in your `wdio.conf.js` file. This service plugin provdies supports for [Browserstack Tunnel](https://wiki.saucelabs.com/display/DOCS/Using+Sauce+Connect+for+Testing+Behind+the+Firewall+or+on+Localhost). Set `browserstackLocal: true` also to activate this feature.
+WebdriverIO has Browserstack support out of the box. You should simply set `user` and `key` in your `wdio.conf.js` file. This service plugin provdies supports for [Browserstack Tunnel](https://www.browserstack.com/automate/node#setting-local-tunnel). Set `browserstackLocal: true` also to activate this feature.
 
 ```js
 // wdio.conf.js


### PR DESCRIPTION
Previously the Browserstack Tunnel link went to a broken Sauce Labs
link, now it goes to the appropriate Browserstack Tunnel link