### PR TITLE
Improve logging of capabilities

### DIFF
--- a/lib/browserstack-service.js
+++ b/lib/browserstack-service.js
@@ -12,8 +12,14 @@ class BrowserstackService {
       auth: this.auth
     }, function(error, response, body) {
       if (!error && response.statusCode === 200) {
-        const { device, browserName, os, os_version, browser, browser_version } = capabilities;
-        const browserString = device ? `${device} ${browserName}` : `${os} ${os_version} ${browser} ${browser_version}`;
+        // These keys describe the browser the test was run on
+        const browserDesc = ['device', 'os', 'osVersion', 'os_version', 'browserName', 'browser', 'browserVersion', 'browser_version'];
+        const browserString = browserDesc.reduce((res, k) => {
+          if (capabilities[k]) {
+            res.push(capabilities[k]);
+          }
+          return res;
+        }, []).join(' ');
         console.log(`[Browserstack] ${browserString} session: ${body.automation_session.browser_url}`);
       }
     });

--- a/lib/browserstack-service.js
+++ b/lib/browserstack-service.js
@@ -14,12 +14,7 @@ class BrowserstackService {
       if (!error && response.statusCode === 200) {
         // These keys describe the browser the test was run on
         const browserDesc = ['device', 'os', 'osVersion', 'os_version', 'browserName', 'browser', 'browserVersion', 'browser_version'];
-        const browserString = browserDesc.reduce((res, k) => {
-          if (capabilities[k]) {
-            res.push(capabilities[k]);
-          }
-          return res;
-        }, []).join(' ');
+        const browserString = browserDesc.filter((k) => capabilities[k]).join(' ');
         console.log(`[Browserstack] ${browserString} session: ${body.automation_session.browser_url}`);
       }
     });


### PR DESCRIPTION
Since there are a variety of keys that can be used to define the "browser" for a given test, derive the "session" descriptor from all such keys with non-empty values (in a particular order). This improves the experience when only certain keys are used, as is supported by BrowserStack.

E.g. given a set of capabilities:
```
{
  browser: 'firefox'
},
{
  browser: 'MicrosoftEdge',
  os: 'Windows',
  os_version: '10'
}
```
generate the string:
```
[Browserstack] firefox session: https://www.browserstack.com/automate/builds/***
[Browserstack] Windows 10 MicrosoftEdge session: https://www.browserstack.com/automate/builds/***
```
instead of:
```
[Browserstack] undefined undefined undefined undefined session: https://www.browserstack.com/automate/builds/***
[Browserstack] Windows 10 undefined undefined session: https://www.browserstack.com/automate/builds/***
```