### PR TITLE
For Cucumber v2+, check for status vs. getFailureException()

### DIFF
--- a/lib/browserstack-service.js
+++ b/lib/browserstack-service.js
@@ -22,7 +22,7 @@ class BrowserstackService {
   }
 
   afterStep (feature) {
-    if (feature.getFailureException()) {
+    if (feature.status === 'failed') {
       ++this.failures
     }
   }


### PR DESCRIPTION
As discussed in https://github.com/itszero/wdio-browserstack-service/issues/12, this pull request brings compatibility with `wdio-cucumber-framework@1.0.0` and higher.

I'll do some more testing this morning to confirm.