### PR TITLE
remove unnecessary dir from published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,11 @@
     "type": "git",
     "url": "git+https://github.com/itszero/wdio-browserstack-service.git"
   },
+  "files": [
+    "index.js",
+    "launcher.js",
+    "build"
+  ],
   "keywords": [
     "webdriverio",
     "wdio",


### PR DESCRIPTION
we don't need `lib` to be deployed with the published package, just the `build`, `index.js`, `launcher.js`