### PR TITLE
Resets session fail count on reload

### DIFF
--- a/lib/browserstack-service.js
+++ b/lib/browserstack-service.js
@@ -32,11 +32,10 @@ class BrowserstackService {
   }
 
   onReload(oldSessionId, newSessionId) {
-
     this.sessionId = newSessionId;
     return this._update(oldSessionId, this._getBody())
       .then(this._printSessionURL())
-      .then(this._reset_failures());
+      .then(() => { this.failures = 0; });
   }
 
   _update(sessionId, body) {
@@ -45,13 +44,6 @@ class BrowserstackService {
       json: true,
       auth: this.auth,
       body
-    });
-  }
-
-  _reset_failures() {
-    return new Promise((resolve) => {
-      this.failures = 0;
-      resolve();
     });
   }
 

--- a/lib/browserstack-service.js
+++ b/lib/browserstack-service.js
@@ -23,7 +23,7 @@ class BrowserstackService {
 
   afterStep (feature) {
     if (feature.getFailureException()) {
-      ++this.failures
+      this.failures++;
     }
   }
 
@@ -34,7 +34,8 @@ class BrowserstackService {
   onReload(oldSessionId, newSessionId) {
     this.sessionId = newSessionId;
     return this._update(oldSessionId, this._getBody())
-      .then(() => this._printSessionURL());
+      .then(() => this._printSessionURL())
+      .then(this.failures = 0);
   }
 
   _update(sessionId, body) {

--- a/lib/browserstack-service.js
+++ b/lib/browserstack-service.js
@@ -32,19 +32,26 @@ class BrowserstackService {
   }
 
   onReload(oldSessionId, newSessionId) {
+
     this.sessionId = newSessionId;
     return this._update(oldSessionId, this._getBody())
-      .then(() => this._printSessionURL())
-      .then(this.failures = 0);
+      .then(this._printSessionURL())
+      .then(this._reset_failures());
   }
 
   _update(sessionId, body) {
-    return request({
-      method: 'PUT',
+    return request.put({
       uri: `https://www.browserstack.com/automate/sessions/${sessionId}.json`,
       json: true,
       auth: this.auth,
       body
+    });
+  }
+
+  _reset_failures() {
+    return new Promise((resolve) => {
+      this.failures = 0;
+      resolve();
     });
   }
 
@@ -56,7 +63,7 @@ class BrowserstackService {
 
   _printSessionURL() {
     const capabilities = global.browser.desiredCapabilities;
-    return request({
+    return request.get({
       uri: `https://www.browserstack.com/automate/sessions/${this.sessionId}.json`,
       json: true,
       auth: this.auth

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "build/index.js",
   "scripts": {
     "build": "gulp",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha"
   },
   "repository": {
     "type": "git",
@@ -28,8 +28,10 @@
   "homepage": "https://github.com/itszero/wdio-browserstack-service#readme",
   "dependencies": {
     "browserstack-local": "^1.2.0",
+    "mocha": "^3.5.3",
     "request": "^2.81.0",
-    "request-promise": "^4.2.1"
+    "request-promise": "^4.2.1",
+    "sinon": "^4.0.0"
   },
   "devDependencies": {
     "gulp": "^3.9.1",

--- a/test/service.js
+++ b/test/service.js
@@ -1,117 +1,112 @@
-var sinon      = require('sinon'),
-request = require('request-promise'),
-Promise = require('bluebird'),
-Browserstack = require('../lib/browserstack-service.js');
+const sinon   = require('sinon');
+const request = require('request-promise');
+const Browserstack = require('../lib/browserstack-service.js');
 
-var getStub;
-var putStub;
+let getStub;
+let putStub;
 
 describe('BrowserstackService', function() {
-	const browserstack = new Browserstack;
-	before(function(){
+  const browserstack = new Browserstack();
+  before(function(){
+    global.browser = {
+      desiredCapabilities: {
+        'device': '',
+        'os': 'OS X',
+        'os_version': 'Sierra',
+        'browserName': 'chrome'
+      }
+    };
 
-		global.browser = {
-			desiredCapabilities: {
-				'device': '',
-				'os': 'OS X',
-				'os_version': 'Sierra',
-				'browserName': 'chrome'
-			}
-		}
+    browserstack.auth = {};
+    browserstack.failures = 0;
+    browserstack.sessionId = 1;
 
-		browserstack.auth = {};
-		browserstack.failures = 0;
-		browserstack.sessionId = 1;
+    putStub = sinon.stub(request, 'put');
+    getStub = sinon.stub(request, 'get');
 
-		putStub = sinon.stub(request,'put');
-		getStub = sinon.stub(request,'get');
+    putStub.resolves(Promise.resolve('{}'));
+    getStub.resolves(Promise.resolve('{}'));
+  });
 
-		putStub.resolves(Promise.resolve('{}'));
-		getStub.resolves(Promise.resolve('{}'));
-	});
-
-	after(function(){
-		request.put.restore;
-		request.get.restore;
-	});
-
-
-	describe('#onReload()', function() {
-		before(function(){
-			sinon.spy(browserstack,'_update');
-		});
-
-		after(function(){
-			browserstack._update.restore;
-		});
+  after(function(){
+    request.put.restore();
+    request.get.restore();
+  });
 
 
-		it('should update and get session', function() {
-			browserstack.onReload(1,2);
-			sinon.assert.called(putStub);
-			sinon.assert.called(getStub);
-		});
+  describe('#onReload()', function() {
+    before(function(){
+      sinon.spy(browserstack, '_update');
+    });
 
-		it('should reset failures', function() {
-			browserstack.failures = 1;
-			browserstack.onReload(1,2);
-			sinon.assert.called(browserstack._update);
-			sinon.match(browserstack.failures, 0);
-		});
+    after(function(){
+      browserstack._update.restore();
+    });
 
-		it('should call functions in the expected order', function() {
-			sinon.spy(browserstack,'_printSessionURL');
-			sinon.spy(browserstack,'_reset_failures');
 
-			browserstack.onReload(1,2);
-			sinon.assert.callOrder(browserstack._update,
-				browserstack._printSessionURL,
-				browserstack._reset_failures);
+    it('should update and get session', function() {
+      browserstack.onReload(1, 2);
+      sinon.assert.called(putStub);
+      sinon.assert.called(getStub);
+    });
 
-			browserstack._printSessionURL.restore;
-			browserstack._reset_failures.restore;
-		});
-	});
+    it('should reset failures', function() {
+      browserstack.failures = 1;
+      browserstack.onReload(1, 2);
+      sinon.assert.called(browserstack._update);
+      sinon.match(browserstack.failures, 0);
+    });
 
-	describe('#_printSessionURL', function() {
-		before(function(){
-			sinon.spy(console, 'log');
-			getStub.callsFake(function(args,func){
-				return Promise.resolve(
-					func(null, {statusCode:200},{
-						"automation_session": {
-							"name": "Smoke Test",
-							"duration": 65,
-							"os": "OS X",
-							"os_version": "Sierra",
-							"browser_version": "61.0",
-							"browser": "chrome",
-							"device": null,
-							"status": "failed",
-							"hashed_id": "1",
-							"reason": "CLIENT_STOPPED_SESSION",
-							"build_name": "WebdriverIO Test",
-							"project_name": "webdriverio",
-							"logs": "https://www.browserstack.com/automate/builds/1/sessions/2/logs",
-							"browser_url": "https://www.browserstack.com/automate/builds/1/sessions/2",
-							"public_url": "https://www.browserstack.com/automate/builds/1/sessions/2",
-							"video_url": "https://www.browserstack.com/s3-upload/bs-video-logs-use/s3/2/video-2.mp4",
-							"browser_console_logs_url": "https://www.browserstack.com/s3-upload/bs-selenium-logs-use/s3/2/2-console-logs.txt",
-							"har_logs_url": "https://www.browserstack.com/s3-upload/bs-video-logs-use/s3/2/2-har-logs.txt"
-						}
-					}));
-				});
-			});
+    it('should call functions in the expected order', function() {
+      sinon.spy(browserstack, '_printSessionURL');
 
-			after(function(){
-				console.log.restore;
-			});
+      browserstack.onReload(1, 2);
+      sinon.assert.callOrder(browserstack._update,
+        browserstack._printSessionURL);
 
-			it('should get and log session details', function() {
-				browserstack._printSessionURL();
-				sinon.assert.calledOnce(console.log );
-				sinon.assert.calledWith( console.log, "[Browserstack] OS X Sierra chrome session: https://www.browserstack.com/automate/builds/1/sessions/2" );
-			});
+      browserstack._printSessionURL.restore();
+    });
+  });
 
-		});
-	});
+  describe('#_printSessionURL', function() {
+    before(function(){
+      sinon.spy(console, 'log');
+      getStub.callsFake(function(args, func){
+        return Promise.resolve(
+          func(null, {statusCode:200}, {
+            'automation_session': {
+              'name': 'Smoke Test',
+              'duration': 65,
+              'os': 'OS X',
+              'os_version': 'Sierra',
+              'browser_version': '61.0',
+              'browser': 'chrome',
+              'device': null,
+              'status': 'failed',
+              'hashed_id': '1',
+              'reason': 'CLIENT_STOPPED_SESSION',
+              'build_name': 'WebdriverIO Test',
+              'project_name': 'webdriverio',
+              'logs': 'https://www.browserstack.com/automate/builds/1/sessions/2/logs',
+              'browser_url': 'https://www.browserstack.com/automate/builds/1/sessions/2',
+              'public_url': 'https://www.browserstack.com/automate/builds/1/sessions/2',
+              'video_url': 'https://www.browserstack.com/s3-upload/bs-video-logs-use/s3/2/video-2.mp4',
+              'browser_console_logs_url': 'https://www.browserstack.com/s3-upload/bs-selenium-logs-use/s3/2/2-console-logs.txt',
+              'har_logs_url': 'https://www.browserstack.com/s3-upload/bs-video-logs-use/s3/2/2-har-logs.txt'
+            }
+          }));
+      });
+    });
+
+    after(function(){
+      console.log.restore();
+    });
+
+    it('should get and log session details', function() {
+      browserstack._printSessionURL();
+      sinon.assert.calledOnce(console.log );
+      sinon.assert.calledWith( console.log, '[Browserstack] OS X Sierra chrome session: https://www.browserstack.com/automate/builds/1/sessions/2' );
+    });
+
+  });
+});

--- a/test/service.js
+++ b/test/service.js
@@ -58,6 +58,19 @@ describe('BrowserstackService', function() {
 			sinon.assert.called(browserstack._update);
 			sinon.match(browserstack.failures, 0);
 		});
+
+		it('should call functions in the expected order', function() {
+			sinon.spy(browserstack,'_printSessionURL');
+			sinon.spy(browserstack,'_reset_failures');
+
+			browserstack.onReload(1,2);
+			sinon.assert.callOrder(browserstack._update,
+				browserstack._printSessionURL,
+				browserstack._reset_failures);
+
+			browserstack._printSessionURL.restore;
+			browserstack._reset_failures.restore;
+		});
 	});
 
 	describe('#_printSessionURL', function() {

--- a/test/service.js
+++ b/test/service.js
@@ -33,7 +33,6 @@ describe('BrowserstackService', function() {
     request.get.restore();
   });
 
-
   describe('#onReload()', function() {
     before(function(){
       sinon.spy(browserstack, '_update');
@@ -42,7 +41,6 @@ describe('BrowserstackService', function() {
     after(function(){
       browserstack._update.restore();
     });
-
 
     it('should update and get session', function() {
       browserstack.onReload(1, 2);

--- a/test/service.js
+++ b/test/service.js
@@ -1,0 +1,104 @@
+var sinon      = require('sinon'),
+request = require('request-promise'),
+Promise = require('bluebird'),
+Browserstack = require('../lib/browserstack-service.js');
+
+var getStub;
+var putStub;
+
+describe('BrowserstackService', function() {
+	const browserstack = new Browserstack;
+	before(function(){
+
+		global.browser = {
+			desiredCapabilities: {
+				'device': '',
+				'os': 'OS X',
+				'os_version': 'Sierra',
+				'browserName': 'chrome'
+			}
+		}
+
+		browserstack.auth = {};
+		browserstack.failures = 0;
+		browserstack.sessionId = 1;
+
+		putStub = sinon.stub(request,'put');
+		getStub = sinon.stub(request,'get');
+
+		putStub.resolves(Promise.resolve('{}'));
+		getStub.resolves(Promise.resolve('{}'));
+	});
+
+	after(function(){
+		request.put.restore;
+		request.get.restore;
+	});
+
+
+	describe('#onReload()', function() {
+		before(function(){
+			sinon.spy(browserstack,'_update');
+		});
+
+		after(function(){
+			browserstack._update.restore;
+		});
+
+
+		it('should update and get session', function() {
+			browserstack.onReload(1,2);
+			sinon.assert.called(putStub);
+			sinon.assert.called(getStub);
+		});
+
+		it('should reset failures', function() {
+			browserstack.failures = 1;
+			browserstack.onReload(1,2);
+			sinon.assert.called(browserstack._update);
+			sinon.match(browserstack.failures, 0);
+		});
+	});
+
+	describe('#_printSessionURL', function() {
+		before(function(){
+			sinon.spy(console, 'log');
+			getStub.callsFake(function(args,func){
+				return Promise.resolve(
+					func(null, {statusCode:200},{
+						"automation_session": {
+							"name": "Smoke Test",
+							"duration": 65,
+							"os": "OS X",
+							"os_version": "Sierra",
+							"browser_version": "61.0",
+							"browser": "chrome",
+							"device": null,
+							"status": "failed",
+							"hashed_id": "1",
+							"reason": "CLIENT_STOPPED_SESSION",
+							"build_name": "WebdriverIO Test",
+							"project_name": "webdriverio",
+							"logs": "https://www.browserstack.com/automate/builds/1/sessions/2/logs",
+							"browser_url": "https://www.browserstack.com/automate/builds/1/sessions/2",
+							"public_url": "https://www.browserstack.com/automate/builds/1/sessions/2",
+							"video_url": "https://www.browserstack.com/s3-upload/bs-video-logs-use/s3/2/video-2.mp4",
+							"browser_console_logs_url": "https://www.browserstack.com/s3-upload/bs-selenium-logs-use/s3/2/2-console-logs.txt",
+							"har_logs_url": "https://www.browserstack.com/s3-upload/bs-video-logs-use/s3/2/2-har-logs.txt"
+						}
+					}));
+				});
+			});
+
+			after(function(){
+				console.log.restore;
+			});
+
+			it('should get and log session details', function() {
+				browserstack._printSessionURL();
+				sinon.assert.calledOnce(console.log );
+				sinon.assert.calledWith( console.log, "[Browserstack] OS X Sierra chrome session: https://www.browserstack.com/automate/builds/1/sessions/2" );
+			});
+
+		});
+	});

--- a/yarn.lock
+++ b/yarn.lock
@@ -137,6 +137,10 @@ braces@^1.8.2:
     preserve "^0.2.0"
     repeat-element "^1.1.2"
 
+browser-stdout@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f"
+
 browserstack-local@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/browserstack-local/-/browserstack-local-1.3.0.tgz#fe80ef05ce8954c4d626e3502eb62d60903b4237"
@@ -210,6 +214,12 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
+  dependencies:
+    graceful-readlink ">= 1.0.0"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -241,7 +251,7 @@ dateformat@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-2.0.0.tgz#2743e3abb5c3fc2462e527dca445e04e9f4dee17"
 
-debug@2:
+debug@2, debug@2.6.8:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
   dependencies:
@@ -271,6 +281,14 @@ detect-file@^0.1.0:
   dependencies:
     fs-exists-sync "^0.1.0"
 
+diff@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
+
+diff@^3.1.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.3.1.tgz#aa8567a6eed03c531fc89d3f711cd0e5259dec75"
+
 duplexer2@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.0.2.tgz#c614dcf67e2fb14995a91711e5a617e8a60a31db"
@@ -296,7 +314,7 @@ end-of-stream@~0.1.5:
   dependencies:
     once "~1.3.0"
 
-escape-string-regexp@^1.0.2:
+escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
@@ -430,6 +448,12 @@ formatio@1.1.1:
   dependencies:
     samsam "~1.1"
 
+formatio@1.2.0, formatio@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.2.0.tgz#f3b2167d9068c4698a8d51f4f760a39a54d818eb"
+  dependencies:
+    samsam "1.x"
+
 fs-exists-sync@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz#982d6893af918e72d08dec9e8673ff2b5a8d6add"
@@ -485,6 +509,17 @@ glob2base@^0.0.12:
   resolved "https://registry.yarnpkg.com/glob2base/-/glob2base-0.0.12.tgz#9d419b3e28f12e83a362164a277055922c9c0d56"
   dependencies:
     find-index "^0.1.1"
+
+glob@7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.2"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
 
 glob@^4.3.1:
   version "4.5.3"
@@ -563,6 +598,14 @@ graceful-fs@^3.0.0:
 graceful-fs@~1.2.0:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-1.2.3.tgz#15a4806a57547cb2d2dbf27f42e89a8c3451b364"
+
+"graceful-readlink@>= 1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
+
+growl@1.9.2:
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/growl/-/growl-1.9.2.tgz#0ea7743715db8d8de2c5ede1775e1b45ac85c02f"
 
 gulp-buble@^0.7.0:
   version "0.7.0"
@@ -660,6 +703,10 @@ has-ansi@^2.0.0:
   dependencies:
     ansi-regex "^2.0.0"
 
+has-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
+
 has-gulplog@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/has-gulplog/-/has-gulplog-0.1.0.tgz#6414c82913697da51590397dafb12f22967811ce"
@@ -674,6 +721,10 @@ hawk@~3.1.3:
     cryptiles "2.x.x"
     hoek "2.x.x"
     sntp "1.x.x"
+
+he@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 
 hoek@2.x.x:
   version "2.16.3"
@@ -871,6 +922,10 @@ json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
+json3@3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
+
 jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
@@ -883,6 +938,10 @@ jsprim@^1.2.2:
     extsprintf "1.0.2"
     json-schema "0.2.3"
     verror "1.3.6"
+
+just-extend@^1.1.22:
+  version "1.1.22"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-1.1.22.tgz#3330af756cab6a542700c64b2e4e4aa062d52fff"
 
 kind-of@^3.0.2:
   version "3.2.2"
@@ -916,9 +975,20 @@ liftoff@^2.1.0, liftoff@^2.3.0:
     rechoir "^0.6.2"
     resolve "^1.1.7"
 
+lodash._baseassign@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz#8c38a099500f215ad09e59f1722fd0c52bfe0a4e"
+  dependencies:
+    lodash._basecopy "^3.0.0"
+    lodash.keys "^3.0.0"
+
 lodash._basecopy@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz#8da0e6a876cf344c0ad8a54882111dd3c5c7ca36"
+
+lodash._basecreate@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz#1bc661614daa7fc311b7d03bf16806a0213cf821"
 
 lodash._basetostring@^3.0.0:
   version "3.0.1"
@@ -952,11 +1022,23 @@ lodash._root@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._root/-/lodash._root-3.0.1.tgz#fba1c4524c19ee9a5f8136b4609f017cf4ded692"
 
+lodash.create@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.create/-/lodash.create-3.1.1.tgz#d7f2849f0dbda7e04682bb8cd72ab022461debe7"
+  dependencies:
+    lodash._baseassign "^3.0.0"
+    lodash._basecreate "^3.0.0"
+    lodash._isiterateecall "^3.0.0"
+
 lodash.escape@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/lodash.escape/-/lodash.escape-3.2.0.tgz#995ee0dc18c1b48cc92effae71a10aab5b487698"
   dependencies:
     lodash._root "^3.0.0"
+
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
 
 lodash.isarguments@^3.0.0:
   version "3.1.0"
@@ -1031,6 +1113,14 @@ lolex@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.3.2.tgz#7c3da62ffcb30f0f5a80a2566ca24e45d8a01f31"
 
+lolex@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.6.0.tgz#3a9a0283452a47d7439e72731b9e07d7386e49f6"
+
+lolex@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.1.2.tgz#2694b953c9ea4d013e5b8bfba891c991025b2629"
+
 lru-cache@2:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.7.3.tgz#6d4524e8b955f95d4f5b58851ce21dd72fb4e952"
@@ -1082,7 +1172,7 @@ mime-types@^2.1.12, mime-types@~2.1.7:
   dependencies:
     mime-db "~1.27.0"
 
-"minimatch@2 || 3", minimatch@^3.0.4:
+"minimatch@2 || 3", minimatch@^3.0.2, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -1109,11 +1199,28 @@ minimist@^1.1.0, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
-mkdirp@^0.5.0:
+mkdirp@0.5.1, mkdirp@^0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
+
+mocha@^3.5.3:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-3.5.3.tgz#1e0480fe36d2da5858d1eb6acc38418b26eaa20d"
+  dependencies:
+    browser-stdout "1.3.0"
+    commander "2.9.0"
+    debug "2.6.8"
+    diff "3.2.0"
+    escape-string-regexp "1.0.5"
+    glob "7.1.1"
+    growl "1.9.2"
+    he "1.1.1"
+    json3 "3.3.2"
+    lodash.create "3.1.1"
+    mkdirp "0.5.1"
+    supports-color "3.1.2"
 
 ms@2.0.0:
   version "2.0.0"
@@ -1129,9 +1236,23 @@ mute-stdout@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/mute-stdout/-/mute-stdout-1.0.0.tgz#5b32ea07eb43c9ded6130434cf926f46b2a7fd4d"
 
+native-promise-only@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/native-promise-only/-/native-promise-only-0.8.1.tgz#20a318c30cb45f71fe7adfbf7b21c99c1472ef11"
+
 natives@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.0.tgz#e9ff841418a6b2ec7a495e939984f78f163e6e31"
+
+nise@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-1.1.0.tgz#37e41b9bf0041ccb83d1bf03e79440bbc0db10ad"
+  dependencies:
+    formatio "^1.2.0"
+    just-extend "^1.1.22"
+    lolex "^1.6.0"
+    path-to-regexp "^1.7.0"
+    text-encoding "^0.6.4"
 
 normalize-path@^2.0.1:
   version "2.1.1"
@@ -1243,6 +1364,12 @@ path-root@^0.1.1:
   resolved "https://registry.yarnpkg.com/path-root/-/path-root-0.1.1.tgz#9a4a6814cac1c0cd73360a95f32083c8ea4745b7"
   dependencies:
     path-root-regex "^0.1.0"
+
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  dependencies:
+    isarray "0.0.1"
 
 performance-now@^0.2.0:
   version "0.2.0"
@@ -1407,6 +1534,10 @@ samsam@1.1.2, samsam@~1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.1.2.tgz#bec11fdc83a9fda063401210e40176c3024d1567"
 
+samsam@1.x, samsam@^1.1.3:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.2.1.tgz#edd39093a3184370cb859243b2bdf255e7d8ea67"
+
 semver-greatest-satisfied-range@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/semver-greatest-satisfied-range/-/semver-greatest-satisfied-range-1.0.0.tgz#4fb441e2a8d26c40b598327557318de272a558a0"
@@ -1442,6 +1573,21 @@ sinon@^1.17.6:
     lolex "1.3.2"
     samsam "1.1.2"
     util ">=0.10.3 <1"
+
+sinon@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-4.0.0.tgz#a54a5f0237aa1dd2215e5e81c89b42b50c4fdb6b"
+  dependencies:
+    diff "^3.1.0"
+    formatio "1.2.0"
+    lodash.get "^4.4.2"
+    lolex "^2.1.2"
+    native-promise-only "^0.8.1"
+    nise "^1.1.0"
+    path-to-regexp "^1.7.0"
+    samsam "^1.1.3"
+    text-encoding "0.6.4"
+    type-detect "^4.0.0"
 
 sntp@1.x.x:
   version "1.0.9"
@@ -1518,6 +1664,12 @@ strip-bom@^1.0.0:
     first-chunk-stream "^1.0.0"
     is-utf8 "^0.2.0"
 
+supports-color@3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
+  dependencies:
+    has-flag "^1.0.0"
+
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
@@ -1527,6 +1679,10 @@ temp-fs@^0.9.9:
   resolved "https://registry.yarnpkg.com/temp-fs/-/temp-fs-0.9.9.tgz#8071730437870720e9431532fe2814364f8803d7"
   dependencies:
     rimraf "~2.5.2"
+
+text-encoding@0.6.4, text-encoding@^0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
 
 through2@^0.6.1:
   version "0.6.5"
@@ -1567,6 +1723,10 @@ tunnel-agent@^0.6.0:
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
+
+type-detect@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.3.tgz#0e3f2670b44099b0b46c284d136a7ef49c74c2ea"
 
 unc-path-regex@^0.1.0:
   version "0.1.2"


### PR DESCRIPTION
Hi, this fixes an issue that I'm seeing, but want to be sure I'm thinking of other people's cases.

I've set up an example that is similar to my use case here: https://github.com/aliking/webdriverio-browserstack

I'm using mocha bdd on browserstack, and I'm using a hook to reload before every example in my spec files, so that each has its own session. 

If I run a test that has multiple examples in it, any examples that run after a fail also get marked failed on Browserstack. 

That example has two spec files, each with two trivial examples: fail_pass.js has one example that fails, then one that passes. The other is called pass_fail.js (you get the idea). 

When I run it, my local reporting of the tests is correct; 2 passes, 2 fails. But on browserstack, there are 3 fails. 

This seems like the simplest way to fix my issue. Can you think of other cases where you wouldn't want to reset the failure count on reload?