### PR TITLE
Automatically apply "browserstack.local = true" to capabilities when running in local mode.

### DIFF
--- a/lib/browserstack-launch-service.js
+++ b/lib/browserstack-launch-service.js
@@ -1,7 +1,7 @@
 const Browserstack = require('browserstack-local');
 
 class BrowserstackLauncherService {
-  onPrepare(config) {
+  onPrepare(config, capabilities) {
     if (!config.browserstackLocal) {
       return;
     }
@@ -12,6 +12,14 @@ class BrowserstackLauncherService {
       ...config.browserstackOpts
     };
     this.browserstackLocal = new Browserstack.Local();
+
+    if (Array.isArray(capabilities)) {
+      capabilities.forEach(capability => {
+        capability['browserstack.local'] = true;
+      });
+    } else if (typeof capabilities === 'object') {
+      capabilities['browserstack.local'] = true;
+    }
 
     return new Promise(resolve => {
       this.browserstackLocal.start(opts, () => resolve());


### PR DESCRIPTION
Fixes https://github.com/itszero/wdio-browserstack-service/issues/3

Also for reference: [onPrepare docs](https://github.com/webdriverio/webdriverio/blob/c7c8dac7069a1eb4d3577573505aaa4ff83f04ac/docs/guide/testrunner/services.md).