### PR TITLE
Propagate browserstack local startup errors

### DIFF
--- a/lib/browserstack-launch-service.js
+++ b/lib/browserstack-launch-service.js
@@ -21,8 +21,13 @@ class BrowserstackLauncherService {
       capabilities['browserstack.local'] = true;
     }
 
-    return new Promise(resolve => {
-      this.browserstackLocal.start(opts, () => resolve());
+    return new Promise((resolve, reject) => {
+      this.browserstackLocal.start(opts, err => {
+        if (err) {
+          return reject(err);
+        }
+        resolve();
+      });
     });
   }
 
@@ -33,8 +38,13 @@ class BrowserstackLauncherService {
     if (config.browserstackLocalForcedStop) {
       return process.kill(this.browserstackLocal.pid);
     }
-    return new Promise(resolve => {
-      this.browserstackLocal.stop(() => resolve());
+    return new Promise((resolve, reject) => {
+      this.browserstackLocal.stop(err => {
+        if (err) {
+          return reject(err);
+        }
+        resolve();
+      });
     });
   }
 }


### PR DESCRIPTION
`browserstackLocal.start` and `.stop` can both fail and they return an error in the standard nodejs callback style (for example: https://github.com/browserstack/browserstack-local-nodejs/blob/ab32965aa6b22c95b256a3c9011f5f53324e7e2c/lib/Local.js#L57). Currently this service silently ignores those errors, causing WDIO to keep going before eventually throwing errors downstream. This PR checks for those errors and propagates them to WDIO via the returned promise.