### PR TITLE
move dev-only dependencies out of package.json hard deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,16 +35,16 @@
   "homepage": "https://github.com/itszero/wdio-browserstack-service#readme",
   "dependencies": {
     "browserstack-local": "^1.2.0",
-    "mocha": "^3.5.3",
     "request": "^2.81.0",
-    "request-promise": "^4.2.1",
-    "sinon": "^4.0.0"
+    "request-promise": "^4.2.1"
   },
   "devDependencies": {
     "cucumber": "^3.0.6",
     "gulp": "^3.9.1",
     "gulp-buble": "^0.7.0",
     "gulp-cli": "^1.2.2",
+    "mocha": "^3.5.3",
+    "sinon": "^4.0.0",
     "prettier": "^1.7.4"
   },
   "prettier": {


### PR DESCRIPTION
They're not needed for the library to work, but also to avoid https://nodesecurity.io/advisories/146 (dependency of older mocha versions)